### PR TITLE
chore: remove dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: monthly
-    commit-message:
-      prefix: build
-      include: scope


### PR DESCRIPTION
I see no benefit in dependabot, too much effort to maintain